### PR TITLE
Make error messages readable

### DIFF
--- a/ktcodeshift-cli/src/main/kotlin/ktcodeshift/App.kt
+++ b/ktcodeshift-cli/src/main/kotlin/ktcodeshift/App.kt
@@ -72,7 +72,13 @@ fun evalScriptSource(sourceCode: SourceCode): TransformFunction {
             val source = d.sourcePath?.let { "$it:" }.orEmpty()
             val locationString = d.location?.start?.let { "${it.line}:${it.col}: " }.orEmpty()
             val extra = d.exception?.let { ": $it" }.orEmpty()
-            println("$source$locationString${d.severity}: ${d.message}$extra")
+            val messageLine = "$source$locationString${d.severity}: ${d.message}$extra"
+            when (d.severity) {
+                ScriptDiagnostic.Severity.ERROR,
+                ScriptDiagnostic.Severity.FATAL -> println(CommandLine.Help.Ansi.AUTO.string("@|bold,red $messageLine |@"))
+                ScriptDiagnostic.Severity.WARNING -> println(CommandLine.Help.Ansi.AUTO.string("@|yellow $messageLine |@"))
+                else -> println(messageLine)
+            }
         }
 
     val transform = transformFunction

--- a/ktcodeshift-cli/src/main/kotlin/ktcodeshift/App.kt
+++ b/ktcodeshift-cli/src/main/kotlin/ktcodeshift/App.kt
@@ -72,6 +72,9 @@ fun evalScriptSource(sourceCode: SourceCode): TransformFunction {
     }
 
     val transform = transformFunction
+    if (transform == null && res.reports.any { it.severity >= ScriptDiagnostic.Severity.ERROR }) {
+        exitProcess(1)
+    }
     checkNotNull(transform) { "transform is not defined." }
     return transform
 }


### PR DESCRIPTION
- Don't show error message "transform is not defined." when an error occurred
- Add location information to error messages
- Print error messages using color

<img width="865" alt="image" src="https://user-images.githubusercontent.com/532251/235451106-ada5e373-1ae2-4904-9f29-94d3c9ca4db7.png">
