### PR TITLE
Use deploy key instead of GITHUB_TOKEN

### DIFF
--- a/.github/workflows/document.yaml
+++ b/.github/workflows/document.yaml
@@ -31,6 +31,6 @@ jobs:
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
           publish_dir: ./build/dokka/htmlMultiModule
           destination_dir: ./${{ github.ref_name }}/api


### PR DESCRIPTION
This is required to run downstream action.